### PR TITLE
Configure secure headers

### DIFF
--- a/docs/.vuepress/public/_headers
+++ b/docs/.vuepress/public/_headers
@@ -1,7 +1,7 @@
 # Response headers configured for basic security
 # docs: https://www.netlify.com/docs/headers-and-basic-auth/
 #       https://www.netlify.com/docs/ssl/#hsts-preload
-# test: https://securityheaders.com/?q=https%3A%2F%2Fkeukentafeltool.netlify.com%2F&hide=on&followRedirects=on
+
 /*
   Referrer-Policy: no-referrer-when-downgrade
   Strict-Transport-Security: max-age=63072000; includeSubDomains; preload

--- a/docs/.vuepress/public/_headers
+++ b/docs/.vuepress/public/_headers
@@ -1,0 +1,10 @@
+# Response headers configured for basic security
+# docs: https://www.netlify.com/docs/headers-and-basic-auth/
+#       https://www.netlify.com/docs/ssl/#hsts-preload
+# test: https://securityheaders.com/?q=https%3A%2F%2Fkeukentafeltool.netlify.com%2F&hide=on&followRedirects=on
+/*
+  Referrer-Policy: no-referrer-when-downgrade
+  Strict-Transport-Security: max-age=63072000; includeSubDomains; preload
+  X-Content-Type-Options: nosniff
+  X-Frame-Options: SAMEORIGIN
+  X-XSS-Protection: 1; mode=block


### PR DESCRIPTION
borrowed from voorhoede/lean-web-kit

**[before](https://securityheaders.com/?q=https%3A%2F%2Fplaybook.voorhoede.nl%2F&hide=on&followRedirects=on)**:
<img width="1210" alt="screen shot 2019-01-09 at 17 09 52" src="https://user-images.githubusercontent.com/1516059/50912032-71fefc80-1431-11e9-9614-c400cf79269b.png">


**[after](https://securityheaders.com/?q=https%3A%2F%2Fdeploy-preview-18--voorhoede-playbook.netlify.com%2F&hide=on&followRedirects=on)**:
<img width="1210" alt="screen shot 2019-01-09 at 17 10 45" src="https://user-images.githubusercontent.com/1516059/50912098-9b1f8d00-1431-11e9-92f5-3c3c510188e9.png">
