### PR TITLE
Paper doc metadata to frontmatter

### DIFF
--- a/src/fetch-papers.js
+++ b/src/fetch-papers.js
@@ -29,10 +29,13 @@ const dropboxPaperApi = got.extend({
   },
 });
 
+const jsonToFrontmatter = json => `---\n${ JSON.stringify(json, null, 2) }\n---\n`;
+
 const {
   fetchAllDocIds,
   getDocFolders,
   fetchDocContent,
+  fetchDocMetaData,
   foldersToPath,
 } = main(dropboxPaperApi);
 
@@ -52,6 +55,7 @@ fetchAllDocIds()
         id,
         folders,
         content: fetchDocContent(id),
+        metaData: fetchDocMetaData(id),
       }))
     )
     .then(Promise.all.bind(Promise))
@@ -70,7 +74,7 @@ fetchAllDocIds()
       mkdir(doc.directory, { recursive: true })
         .then(() => writeFile(
           doc.location,
-          doc.content.body
+          `${jsonToFrontmatter(doc.metaData)}${doc.content.body}`
         ));
       writeFile('docs/dump.json', JSON.stringify(docs));
     }));

--- a/src/main.js
+++ b/src/main.js
@@ -59,7 +59,7 @@ const fetchDocContent = apiFetch => docId => apiFetch(
     body,
   }));
 
-const fetchDocMetaData = apiFetch => docId =>   apiFetch(
+const fetchDocMetaData = apiFetch => docId => apiFetch(
     '/docs/get_metadata',
     { body: { doc_id: docId } }
   )

--- a/src/main.js
+++ b/src/main.js
@@ -59,6 +59,12 @@ const fetchDocContent = apiFetch => docId => apiFetch(
     body,
   }));
 
+const fetchDocMetaData = apiFetch => docId =>   apiFetch(
+    '/docs/get_metadata',
+    { body: { doc_id: docId } }
+  )
+  .then(({ body }) => body);
+
 const getDocFolders = apiFetch => docId => fetchDocFolders (apiFetch) (docId)
   .then(gets (Boolean) (['body', 'folders']))
   .catch(response =>
@@ -74,4 +80,5 @@ module.exports = apiFetch => ({
   fetchAllDocIds: fetchAllDocIds(apiFetch),
   fetchDocFolders,
   fetchDocContent: fetchDocContent(apiFetch),
+  fetchDocMetaData: fetchDocMetaData(apiFetch),
 });


### PR DESCRIPTION
Fetch Paper document metadata and prepend it as frontmatter to the markdown file written to `docs/`.