### PR TITLE
Add Netlify deploy status badge to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -2,7 +2,7 @@
 [![Travis Build Status][travis-icon]][travis]
 [![David Dependencies Status][david-icon]][david]
 [![LGTM Grade][lgtm-icon]][lgtm]
-[![Netlify Status](https://api.netlify.com/api/v1/badges/6cb9ad83-2aee-4233-9ed3-62d0fa799b9f/deploy-status)](https://app.netlify.com/sites/voorhoede-playbook/deploys)
+[![Netlify Status][netlify-icon]][netlify]
 
 Playbook in the form of a website generated with [Vuepress](https://vuepress.vuejs.org/) and fetched [Dropbox Paper](https://www.dropbox.com/paper) documents.
 
@@ -54,3 +54,5 @@ The code is written in a functional style using [Sanctuary](https://sanctuary.js
 [david-icon]: https://img.shields.io/david/voorhoede/playbook.svg?style=flat-square
 [lgtm]: https://lgtm.com/projects/g/voorhoede/playbook/
 [lgtm-icon]: https://img.shields.io/lgtm/grade/javascript/g/voorhoede/playbook.svg?style=flat-square
+[netlify]: https://app.netlify.com/sites/voorhoede-playbook/deploys
+[netlify-icon]: https://api.netlify.com/api/v1/badges/6cb9ad83-2aee-4233-9ed3-62d0fa799b9f/deploy-status

--- a/readme.md
+++ b/readme.md
@@ -2,6 +2,7 @@
 [![Travis Build Status][travis-icon]][travis]
 [![David Dependencies Status][david-icon]][david]
 [![LGTM Grade][lgtm-icon]][lgtm]
+[![Netlify Status](https://api.netlify.com/api/v1/badges/6cb9ad83-2aee-4233-9ed3-62d0fa799b9f/deploy-status)](https://app.netlify.com/sites/voorhoede-playbook/deploys)
 
 Playbook in the form of a website generated with [Vuepress](https://vuepress.vuejs.org/) and fetched [Dropbox Paper](https://www.dropbox.com/paper) documents.
 


### PR DESCRIPTION
This pull-request includes:
- Added new Netlify deploy status badge to the `readme.md`.

Fixed #43